### PR TITLE
fix(deps): patch CVEs in drizzle-orm and zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tailwindcss/vite": "4.2.1",
         "@xyflow/react": "12.10.1",
         "astro": "5.18.0",
-        "drizzle-orm": "0.45.1",
+        "drizzle-orm": "0.45.2",
         "elkjs": "0.11.0",
         "fflate": "0.8.2",
         "html-to-image": "1.11.11",
@@ -22,7 +22,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwindcss": "4.2.1",
-        "zod": "^3.24.0",
+        "zod": "^4.0.0",
         "zustand": "5.0.11"
       },
       "devDependencies": {
@@ -5985,6 +5985,24 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/astro/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/astro/node_modules/zod-to-ts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+      "peerDependencies": {
+        "typescript": "^4.9.4 || ^5.0.2",
+        "zod": "^3"
+      }
+    },
     "node_modules/astrojs-compiler-sync": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
@@ -7580,9 +7598,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
-      "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -14874,9 +14892,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -14889,15 +14907,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tailwindcss/vite": "4.2.1",
     "@xyflow/react": "12.10.1",
     "astro": "5.18.0",
-    "drizzle-orm": "0.45.1",
+    "drizzle-orm": "0.45.2",
     "elkjs": "0.11.0",
     "fflate": "0.8.2",
     "html-to-image": "1.11.11",
@@ -42,7 +42,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "4.2.1",
-    "zod": "^3.24.0",
+    "zod": "^4.0.0",
     "zustand": "5.0.11"
   },
   "devDependencies": {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -141,8 +141,8 @@ export const DiagramResponseSchema = apiResponseSchema(DiagramSchema);
 
 /** Zod schema for the parsed contents of a diagram's `graphData` JSON string. */
 export const GraphDataSchema = z.object({
-  nodes: z.array(z.record(z.unknown())).default([]),
-  edges: z.array(z.record(z.unknown())).default([]),
+  nodes: z.array(z.record(z.string(), z.unknown())).default([]),
+  edges: z.array(z.record(z.string(), z.unknown())).default([]),
   viewport: z
     .object({ x: z.number(), y: z.number(), zoom: z.number() })
     .default({ x: 0, y: 0, zoom: 1 }),


### PR DESCRIPTION
- Bump drizzle-orm 0.45.1 -> 0.45.2 (fixes SQL injection via sql.identifier/sql.as, CWE-89)
- Bump zod ^3.24.0 -> ^4.0.0 (high severity CVE)
- Fix z.record() call signature in validation.ts: Zod v4 requires explicit key schema (z.record(z.string(), z.unknown()) instead of z.record(z.unknown()))