### PR TITLE
refactor(env): centralise Cloudflare env access behind getEnv()

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,19 @@
+/**
+ * Cloudflare environment bindings accessor.
+ *
+ * Single seam for obtaining the typed `Env` bindings (D1, KV, vars) on every
+ * request. All route handlers and middleware call `getEnv(locals)` rather than
+ * reaching into `locals.runtime.env` directly.
+ *
+ * This indirection exists so that the upcoming Astro 6 / @astrojs/cloudflare
+ * v13 migration (Phase 3) only needs to change this one file. In v13, the
+ * adapter removes `locals.runtime` in favour of a direct module import:
+ *
+ *   import { env } from "cloudflare:workers";
+ *
+ * When that change is made, every call site that already uses `getEnv(locals)`
+ * will continue to compile and run without modification.
+ */
+export function getEnv(locals: App.Locals): Env {
+  return locals.runtime.env;
+}

--- a/src/lib/repository/index.ts
+++ b/src/lib/repository/index.ts
@@ -31,8 +31,8 @@ export type {
 /**
  * Create repository instances wired to the given Cloudflare bindings.
  *
- * Call once per request with `locals.runtime.env` (in API routes) or
- * `Astro.locals.runtime.env` (in Astro pages).
+ * Call once per request with `getEnv(locals)` (in API routes) or
+ * `getEnv(Astro.locals)` (in Astro pages).
  */
 export function createRepositories(env: { DB: D1Database; KV: KVNamespace }) {
   const db = createDb(env.DB);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@
  */
 import { defineMiddleware } from "astro:middleware";
 import { cloudflareAccessAuth } from "./lib/auth/cloudflare-access";
+import { getEnv } from "./lib/env";
 import { createRepositories } from "./lib/repository";
 
 const PROTECTED_PATTERNS = [
@@ -36,7 +37,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return next();
   }
 
-  const env = context.locals.runtime.env;
+  const env = getEnv(context.locals);
 
   const user = await cloudflareAccessAuth.resolveUser(context.request, env);
 

--- a/src/pages/api/v1/admin/users/[id].ts
+++ b/src/pages/api/v1/admin/users/[id].ts
@@ -4,6 +4,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { UpdateUserAdminSchema, apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -19,7 +20,7 @@ export async function DELETE({ params, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { users } = createRepositories(locals.runtime.env);
+  const { users } = createRepositories(getEnv(locals));
   const deleted = await users.delete(id!);
 
   if (!deleted) {
@@ -49,7 +50,7 @@ export async function PATCH({ params, request, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { users } = createRepositories(locals.runtime.env);
+  const { users } = createRepositories(getEnv(locals));
   const updated = await users.setAdmin(id!, parsed.data.isAdmin);
 
   if (!updated) {

--- a/src/pages/api/v1/admin/users/index.ts
+++ b/src/pages/api/v1/admin/users/index.ts
@@ -4,6 +4,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import type { ListUsersOptions } from "@lib/repository";
 import { apiSuccess } from "@lib/validation";
@@ -33,7 +34,7 @@ export async function GET({ locals, url }: APIContext) {
 
   const search = url.searchParams.get("search") || undefined;
 
-  const { users } = createRepositories(locals.runtime.env);
+  const { users } = createRepositories(getEnv(locals));
   const result = await users.list({
     page,
     pageSize,

--- a/src/pages/api/v1/diagrams/[id].ts
+++ b/src/pages/api/v1/diagrams/[id].ts
@@ -4,6 +4,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { UpdateDiagramSchema, apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -18,7 +19,7 @@ export async function GET({ params, locals }: APIContext) {
   if (!locals.user) {
     return jsonResponse(apiError("UNAUTHORIZED", "Unauthorized").body, 401);
   }
-  const { diagrams } = createRepositories(locals.runtime.env);
+  const { diagrams } = createRepositories(getEnv(locals));
   const row = await diagrams.getByIdAndOwner(params.id!, locals.user.id);
 
   if (!row) {
@@ -48,7 +49,7 @@ export async function PATCH({ request, params, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { diagrams } = createRepositories(locals.runtime.env);
+  const { diagrams } = createRepositories(getEnv(locals));
   const updated = await diagrams.updateMetadata(
     params.id!,
     locals.user.id,
@@ -73,7 +74,7 @@ export async function DELETE({ params, locals }: APIContext) {
   if (!locals.user) {
     return jsonResponse(apiError("UNAUTHORIZED", "Unauthorized").body, 401);
   }
-  const { diagrams, shares } = createRepositories(locals.runtime.env);
+  const { diagrams, shares } = createRepositories(getEnv(locals));
 
   await shares.revokeAllForDiagram(params.id!);
   const removed = await diagrams.remove(params.id!, locals.user.id);

--- a/src/pages/api/v1/diagrams/[id]/graph.ts
+++ b/src/pages/api/v1/diagrams/[id]/graph.ts
@@ -3,6 +3,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { SaveGraphSchema, apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -26,7 +27,7 @@ export async function PUT({ request, params, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { diagrams } = createRepositories(locals.runtime.env);
+  const { diagrams } = createRepositories(getEnv(locals));
   const updatedAt = await diagrams.saveGraphData(
     params.id!,
     locals.user.id,

--- a/src/pages/api/v1/diagrams/[id]/share.ts
+++ b/src/pages/api/v1/diagrams/[id]/share.ts
@@ -3,6 +3,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { CreateShareSchema, apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -26,7 +27,7 @@ export async function POST({ request, params, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { diagrams, shares } = createRepositories(locals.runtime.env);
+  const { diagrams, shares } = createRepositories(getEnv(locals));
 
   const existing = await diagrams.getByIdAndOwner(params.id!, locals.user.id);
   if (!existing) {
@@ -69,7 +70,7 @@ export async function DELETE({ request, params, locals }: APIContext) {
     return jsonResponse(err.body, err.status);
   }
 
-  const { shares } = createRepositories(locals.runtime.env);
+  const { shares } = createRepositories(getEnv(locals));
 
   const link = await shares.getByTokenDiagramAndCreator(
     token,

--- a/src/pages/api/v1/diagrams/index.ts
+++ b/src/pages/api/v1/diagrams/index.ts
@@ -4,6 +4,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { CreateDiagramSchema, apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -19,7 +20,7 @@ export async function GET({ locals }: APIContext) {
   if (!locals.user) {
     return jsonResponse(apiError("UNAUTHORIZED", "Unauthorized").body, 401);
   }
-  const { diagrams } = createRepositories(locals.runtime.env);
+  const { diagrams } = createRepositories(getEnv(locals));
   const rows = await diagrams.listByOwner(locals.user.id);
   return jsonResponse(apiSuccess(rows));
 }
@@ -60,7 +61,7 @@ export async function POST({ request, locals }: APIContext) {
     graphData = bp.graphData;
   }
 
-  const { diagrams } = createRepositories(locals.runtime.env);
+  const { diagrams } = createRepositories(getEnv(locals));
   const row = await diagrams.create({
     ownerId: locals.user.id,
     title,

--- a/src/pages/api/v1/share/[token].ts
+++ b/src/pages/api/v1/share/[token].ts
@@ -4,6 +4,7 @@
  */
 
 import type { APIContext } from "astro";
+import { getEnv } from "@lib/env";
 import { createRepositories } from "@lib/repository";
 import { apiSuccess, apiError } from "@lib/validation";
 import { jsonResponse } from "@lib/helpers";
@@ -16,7 +17,7 @@ import { jsonResponse } from "@lib/helpers";
  * @returns The diagram data, or 404 if token is expired or not found
  */
 export async function GET({ params, locals }: APIContext) {
-  const { shares } = createRepositories(locals.runtime.env);
+  const { shares } = createRepositories(getEnv(locals));
   const diagram = await shares.loadDiagramFromShareLink(params.token!);
 
   if (!diagram) {

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../components/Layout.astro";
 import DiagramCanvasWrapper from "../../islands/DiagramCanvasWrapper";
+import { getEnv } from "../../lib/env";
 import { createRepositories } from "../../lib/repository";
 
 const { token } = Astro.params;
@@ -8,7 +9,7 @@ if (!token) {
   return Astro.redirect("/dashboard");
 }
 
-const { shares } = createRepositories(Astro.locals.runtime.env);
+const { shares } = createRepositories(getEnv(Astro.locals));
 const diagram = await shares.loadDiagramFromShareLink(token);
 
 if (!diagram) {

--- a/tests/helpers/mock-context.ts
+++ b/tests/helpers/mock-context.ts
@@ -25,9 +25,9 @@ export interface MockContextOptions {
   params?: Record<string, string>;
   /** Override the default test user. Pass `undefined` to simulate unauthenticated. */
   user?: AppUser | undefined;
-  /** MockDatabase instance to wire into locals.runtime.env.DB. */
+  /** MockDatabase instance to wire into the env DB binding. */
   db?: MockDatabase;
-  /** MockKV instance to wire into locals.runtime.env.KV. */
+  /** MockKV instance to wire into the env KV binding. */
   kv?: MockKV;
 }
 
@@ -35,8 +35,8 @@ export interface MockContextOptions {
  * Build a minimal APIContext-shaped object suitable for calling route handlers.
  *
  * The returned object has `request`, `params`, and `locals` matching what
- * Astro injects. The `locals.runtime.env` is wired to the provided mock DB
- * and mock KV instances.
+ * Astro injects. The env bindings (DB, KV) are wired to the provided mock
+ * instances via `locals.runtime.env` (the current Astro 5 / cloudflare v12 shape).
  */
 export function createMockContext(options: MockContextOptions = {}) {
   const {


### PR DESCRIPTION
Introduce src/lib/env.ts as a single seam for accessing Cloudflare runtime bindings (D1, KV, vars). All API routes, middleware, and Astro pages now call getEnv(locals) instead of reaching into locals.runtime.env directly.

This is a zero-functional-change refactor that isolates the locals.runtime API to one file, so the Phase 3 (Astro 6 / @astrojs/cloudflare v13) migration only needs to swap the implementation of getEnv() to use 'import { env } from "cloudflare:workers"' — leaving all 11 call sites untouched.